### PR TITLE
Using public image and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM docker-registry.usersys.redhat.com/goldmann/jboss-eap:6.3
+FROM paterczm/docker-fedora20-jbossas7
 MAINTAINER Luan Cestari <lcestari@redhat.com> 
 
 ENV LIGHTBLUE_VERSION_MAJOR 1
-ENV LIGHTBLUE_VERSION_MINOR 1
+ENV LIGHTBLUE_VERSION_MINOR 2
 ENV LIGHTBLUE_VERSION_MICRO 0
 ENV LIGHTBLUE_VERSION $LIGHTBLUE_VERSION_MAJOR.$LIGHTBLUE_VERSION_MINOR.$LIGHTBLUE_VERSION_MICRO
+ENV JBOSS_HOME=/opt/jbossas7
 
-RUN curl -o crud.war      https://repo1.maven.org/maven2/com/redhat/lightblue/rest/rest-crud/$LIGHTBLUE_VERSION/rest-crud-$LIGHTBLUE_VERSION.war         && mv crud.war $JBOSS_HOME/standalone/deployments/
-RUN curl -o metadata.war  https://repo1.maven.org/maven2/com/redhat/lightblue/rest/rest-metadata/$LIGHTBLUE_VERSION/rest-metadata-$LIGHTBLUE_VERSION.war && mv metadata.war $JBOSS_HOME/standalone/deployments/
+RUN curl -o $JBOSS_HOME/standalone/deployments/crud.war https://repo1.maven.org/maven2/com/redhat/lightblue/rest/rest-crud/$LIGHTBLUE_VERSION/rest-crud-$LIGHTBLUE_VERSION.war
+RUN curl -o $JBOSS_HOME/standalone/deployments/metadata.war https://repo1.maven.org/maven2/com/redhat/lightblue/rest/rest-metadata/$LIGHTBLUE_VERSION/rest-metadata-$LIGHTBLUE_VERSION.war
 RUN mkdir -p $JBOSS_HOME/modules/com/redhat/lightblue/main
 
 ADD lightblue_config $JBOSS_HOME/modules/com/redhat/lightblue/main/

--- a/README.md
+++ b/README.md
@@ -2,19 +2,17 @@
 
 This repository is responsible to create the lightblue project deploy on any machine using Docker.
 
-NOTE: As the firsts iterations we are going to use an image from our internal Docker repository because we are going to deploy using Red Hat JBoss EAP. There is a problem need to be solved to lightblue work with Wildfly right now, you can contribute solving this issue so we can remove the internal dependency (More about it on http://forum.lightblue.io/Unable-to-deploy-lightblue-on-wildfly-td4.html#a7 ).
-
 # Roadmap
 
 You can see what we are looking foward with this repository looking at the [Roadmap.md](https://github.com/lightblue-platform/lightblue-dockerfile/blob/master/Roadmap.md) file.
 
 # Requirements
 
-For this repository you will need to have [Docker](https://www.docker.com/) and [Fig](http://www.fig.sh/) installed. 
+For this repository you will need to have [Docker](https://www.docker.com/) and [Docker Compose](http://docs.docker.com/compose/) installed.
 
 # How to run
 
-Just clone this repository and inside this folder run `fig up`.
+Just clone this repository and inside this folder run `docker-compose up`.
 
 # Books!
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 lightblue:
   build: .
-  command: /opt/jboss/eap/bin/standalone.sh -b 0.0.0.0
+  command: /opt/jbossas7/bin/standalone.sh -b 0.0.0.0
   ports:
    - "8080:8080"
 #  volumes:


### PR DESCRIPTION
I propose to use a public JBoss AS 7 image to run lightblue. Also using docker-compose instead of deprecated fig.