### PR TITLE
Using Terraform to setup lightblue environment on docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Once started, you will have following services available:
 * Data Management App: http://localhost:8081/app/data
 * Metadata Management App: http://localhost:8081/app/metadata
 
-## Running without docker-compose
+## [Running using terraform](terraform)
+
+## Running using bare docker
 Docker-compose does not work everywhere (at the time of writing, it's broken on Fedora 22). Here is how you can link lightblue containers togeather using only docker:
 ```
 docker run -d --name mongodb docker.io/mongo mongod --rest --httpinterface --smallfiles

--- a/lightblue-latest/localdeploy.sh
+++ b/lightblue-latest/localdeploy.sh
@@ -8,7 +8,9 @@ fi
 
 case "$1" in
 
-    undeploy) $JBOSS_HOME/bin/jboss-cli.sh --controller=localhost --user=admin --password=redhat -c "undeploy crud.war"
+    undeploy-crud) $JBOSS_HOME/bin/jboss-cli.sh --controller=localhost --user=admin --password=redhat -c "undeploy crud.war"
+    ;;
+    undeploy-metadata) $JBOSS_HOME/bin/jboss-cli.sh --controller=localhost --user=admin --password=redhat -c "undeploy metadata.war"
     ;;
     deploy)  $JBOSS_HOME/bin/jboss-cli.sh --controller=localhost --user=admin --password=redhat -c "deploy $2 --force"
     ;;
@@ -17,8 +19,9 @@ case "$1" in
     *)
         echo "A utility script to deploy locally built lightblue-crud.war on docker. Uses jboss-cli interface."
         echo "USAGE:"
-        echo "$0 undeploy # undeploys crud.war"
-        echo "$0 deploy <path to crud.war> # deploys specified crud.war in docker"
+        echo "$0 undeploy-crud # undeploys crud.war"
+        echo "$0 undeploy-metdata # undeploys metadata.war"
+        echo "$0 deploy <path to crud.war> # deploys specified war in docker"
         echo "$0 list # lists deployments"
    ;;
 esac

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,2 @@
+*.tfstate
+*.backup

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -15,7 +15,7 @@ You can specify versions:
 ```
 terraform apply -var 'lightblue_version:1.2.0' -var 'lightblue_apps_version:1.2.0'
 ```
-By default, latest version is taken.
+By default, latest version is taken. See Docker Hub for a list of all available [lightblue versions](https://hub.docker.com/r/lightblue/lightblue/tags/) and [lightblue apps versions](https://hub.docker.com/r/lightblue/applications/tags/).
 
 Once started, you will have following services available:
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,25 @@
+[Terraform](https://www.terraform.io/intro/index.html) script to run lightblue using [docker provider](https://www.terraform.io/docs/providers/docker/index.html).
+
+## Terraform
+
+To install Terraform, just [download](https://www.terraform.io/downloads.html) and unpack it. No setup is needed.
+
+## How to run
+
+Assuming you have docker available via tcp://127.0.0.1:4243, just run in the terraform directory (where main.tf script is):
+```
+terraform apply
+```
+
+You can specify versions:
+```
+terraform apply -var 'lightblue_version:1.2.0' -var 'lightblue_apps_version:1.2.0'
+```
+By default, latest version is taken.
+
+Once started, you will have following services available:
+
+* Data endpoint: http://localhost:8080/rest/data
+* Metadata endpoint: http://localhost:8080/rest/metadata
+* Data Management App: http://localhost:8081/app/data
+* Metadata Management App: http://localhost:8081/app/metadata

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,70 @@
+# Configure the Docker provider
+provider "docker" {
+        host = "tcp://127.0.0.1:4243/"
+}
+
+# Create a mongo container
+resource "docker_container" "mongo" {
+        image = "${docker_image.mongo.latest}"
+        name = "lbmongo"
+        command = ["mongod", "--rest", "--httpinterface", "--smallfiles"]
+}
+
+# Create a lightblue container
+resource "docker_container" "lightblue" {
+        image = "${docker_image.lightblue.latest}"
+        name = "lightblue"
+        ports {
+           "internal" = "8080"
+           "external" = "${var.lightblue_port}"
+        }
+        #ports {
+        #   "internal" = "9999"
+        #   "external" = "9999"
+        #}
+        links = ["lbmongo:mongodb"]
+        command = ["/opt/jbossas7/bin/standalone.sh", "-b", "0.0.0.0", "-Djboss.bind.address.management=0.0.0.0"]
+        depends_on = ["docker_container.mongo"]
+}
+
+# Create a lightblue applications container
+resource "docker_container" "lightblue_apps" {
+        image = "${docker_image.lightblue_apps.latest}"
+        name = "lightblue_apps"
+        ports {
+           "internal" = "8080"
+           "external" = "${var.lightblue_apps_port}"
+        }
+        links = ["lightblue:lightblue"]
+        command = ["/opt/jbossas7/bin/standalone.sh", "-b", "0.0.0.0"]
+        depends_on = ["docker_container.lightblue"]
+}
+
+resource "docker_image" "mongo" {
+        name = "docker.io/mongo:latest"
+}
+
+resource "docker_image" "lightblue" {
+        name = "docker.io/lightblue/lightblue:${var.lightblue_version}"
+}
+
+resource "docker_image" "lightblue_apps" {
+        name = "docker.io/lightblue/applications:${var.lightblue_apps_version}"
+}
+
+variable "lightblue_version" {
+    default = "latest"
+}
+
+
+variable "lightblue_port" {
+    default = "8080"
+}
+
+variable "lightblue_apps_version" {
+    default = "latest"
+}
+
+variable "lightblue_apps_port" {
+    default = "8081"
+}


### PR DESCRIPTION
This is an attempt to ditch docker-compose, which is causing me problems on Fedora 22. Terraform supports templates with variables, so only one startup script is needed for all lightblue versions (we need one docker-compose.yaml for each version).

Next step might be to use [Packer](https://www.packer.io/docs/builders/docker.html) instead of Dockerfiles.