### PR TITLE
bugfix for dockerfile/mongodb is unavailable #21

### DIFF
--- a/lightblue-latest/docker-compose.yml
+++ b/lightblue-latest/docker-compose.yml
@@ -7,7 +7,7 @@ lightblue:
   links:
       - mongodb:mongodb
 mongodb:
-  image: dockerfile/mongodb
+  image: library/mongo
   command: mongod --rest --httpinterface --smallfiles
   ports:
    - "28017:28017"


### PR DESCRIPTION
MongoImage name changed [dockerfile/mongodb#17] (https://github.com/dockerfile/mongodb/pull/17/files)
